### PR TITLE
Fix percentage precision

### DIFF
--- a/src/lib/GaugeChart/index.js
+++ b/src/lib/GaugeChart/index.js
@@ -248,7 +248,7 @@ class GaugeChart extends React.Component {
         .attr("class", "text-group")
         .attr("transform", `translate(${this.outerRadius}, ${this.outerRadius / 2 + textPadding})`)
       .append("text")
-        .text(`${percentage*100}%`)
+      .text(`${this.floatingNumber(percentage)}%`)
         .style("font-size", () => {
           if(this.width < 500 || this.height < 250) return 40;
           if(this.width < 1000 || this.height < 500) return 80;
@@ -256,6 +256,10 @@ class GaugeChart extends React.Component {
         })
         .style("fill", this.props.textColor)
         .attr("class", "percent-text");
+  }
+
+  floatingNumber=(value,maxDigits=2) => {
+    return Math.round((value*100)*(10**maxDigits))/10**maxDigits
   }
 
   render() {


### PR DESCRIPTION
For example, when a Gauge has 0.56 as percentage, it displays 56.00000000001%
![Screenshot from 2019-06-07 09-51-22](https://user-images.githubusercontent.com/12515407/59089231-ddc69200-8909-11e9-9cf3-d84c17f1e290.png)

Here is an example (with code) about that bug : [https://codesandbox.io/s/aged-smoke-gk77z](https://codesandbox.io/s/aged-smoke-gk77z)