### PR TITLE
fix font size for percentage text

### DIFF
--- a/src/lib/GaugeChart/index.js
+++ b/src/lib/GaugeChart/index.js
@@ -249,11 +249,7 @@ class GaugeChart extends React.Component {
         .attr("transform", `translate(${this.outerRadius}, ${this.outerRadius / 2 + textPadding})`)
       .append("text")
         .text(`${percentage*100}%`)
-        .style("font-size", () => {
-          if(this.width < 500 || this.height < 250) return 40;
-          if(this.width < 1000 || this.height < 500) return 80;
-          else return 100;
-        })
+        .style("font-size", () => `${this.width / 10}px`)
         .style("fill", this.props.textColor)
         .attr("class", "percent-text");
   }


### PR DESCRIPTION
Now, percentage text should increase and decrease following container width.

Here is an example about that bug : https://codesandbox.io/s/aged-smoke-gk77z