### PR TITLE
feat: add className and style props to div container

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ The props for the chart:
 | Name            | PropType                    | Description                                                    | Default value          |
 |-----------------|-----------------------------|----------------------------------------------------------------|------------------------|
 | id              | PropTypes.string.isRequired | Used for the identification of the div surrounding the chart   |                        |
+| className       | PropTypes.string            | Add `className` to the div container                           |                        |
+| style           | PropTypes.object            | Add `style` to the div container                               | { width: '100%' }      |
 | marginInPercent | PropTypes.number            | Margin for the chart inside the containing SVG element         | 0.05                   |
 | cornerRadius    | PropTypes.number            | Corner radius for the elements in the chart                    | 6                      |
 | nrOfLevels      | PropTypes.number            | The number of elements displayed in the arc                    | 3                      |
@@ -72,4 +74,3 @@ each arc would a color in the array (colors are assigned from left to right). If
 must match the **number of levels** in the arc.
 If the number of colors does not match the number of levels, then the **first** and the **last** color from the colors array will
 be selected and the arcs will get colors that are interpolated between those. The interpolation is done using [d3.interpolateHsl](https://github.com/d3/d3-interpolate#interpolateHsl).
-

--- a/src/lib/GaugeChart/index.js
+++ b/src/lib/GaugeChart/index.js
@@ -17,6 +17,10 @@ TODO: Lägg till info om 'data' i docs
 const startAngle = -Math.PI/2;  //Negative x-axis
 const endAngle = Math.PI/2;     //Positive x-axis
 
+const defaultStyle = {
+  width: '100%',
+};
+
 // Props that should cause an animation on update
 const animateNeedleProps = [
   'marginInPercent',
@@ -26,7 +30,7 @@ const animateNeedleProps = [
 ];
 
 class GaugeChart extends React.Component {
-  //TODO: Change props to props    
+  //TODO: Change props to props
   constructor(props) {
     super(props);
     const { nrOfLevels, colors } = this.props;
@@ -42,7 +46,7 @@ class GaugeChart extends React.Component {
     this.margin = {};  // = {top: 20, right: 50, bottom: 50, left: 50},
     this.arc = d3.arc();
     this.pie = d3.pie();
-    
+
     //Check if the number of colors equals the number of levels
     //Otherwise make an interpolation
     if(nrOfLevels === colors.length){
@@ -67,14 +71,14 @@ class GaugeChart extends React.Component {
     if(this.props.id){
       this.container = d3.select(`#${this.props.id}`);
       //Initialize chart
-      this.initChart();  
+      this.initChart();
     }
   }
 
   componentDidUpdate(prevProps) {
     //Initialize chart
     //TODO: Maybe not call this here?
-    
+
     // Always redraw the chart, but potentially do not animate it
     const resize = !animateNeedleProps.some(key => prevProps[key] !== this.props[key]);
     this.initChart(true, resize);
@@ -90,7 +94,7 @@ class GaugeChart extends React.Component {
     this.g = this.svg.append("g")   //Used for margins
     this.doughnut = this.g.append("g")
       .attr("class", "doughnut");
-    
+
       //Set up the pie generator
     //Each arc should be of equal length (or should they?)
     this.pie.value(function(d) { return d.value; })
@@ -183,7 +187,7 @@ class GaugeChart extends React.Component {
     this.margin.left = this.width/2 - this.outerRadius + this.margin.right;
     this.g.attr("transform", "translate(" + this.margin.left + ", " + this.margin.top + ")");
   }
-  
+
   //If 'resize' is true then the animation does not play
   drawNeedle = (resize) => {
     const { percent, needleColor, needleBaseColor, hideText } = this.props;
@@ -276,16 +280,15 @@ class GaugeChart extends React.Component {
   }
 
   render() {
-    return (
-      <div id={this.props.id} style={{width: "100%"}} >
-      </div>
-    )
+    const { id, style, className } = this.props;
+    return <div id={id} className={className} style={style} />;
   }
 }
 
 export default GaugeChart;
 
 GaugeChart.defaultProps = {
+  style: defaultStyle,
   marginInPercent: 0.05,
   cornerRadius: 6,
   nrOfLevels: 3,
@@ -301,6 +304,8 @@ GaugeChart.defaultProps = {
 
 GaugeChart.propTypes = {
   id: PropTypes.string.isRequired,
+  className: PropTypes.string,
+  style: PropTypes.object,
   marginInPercent: PropTypes.number,
   cornerRadius: PropTypes.number,
   nrOfLevels: PropTypes.number,


### PR DESCRIPTION
Allow customize the div container. Could be usefull to set specific height and width and vertical align the svg inside the container. Something like that:
```
style={{ width: 800, height: 600, display: 'flex', alignItems: 'center' }}
```