### PR TITLE
Clear container of SVG before rendering

### DIFF
--- a/src/lib/GaugeChart/index.js
+++ b/src/lib/GaugeChart/index.js
@@ -75,6 +75,7 @@ const GaugeChart = (props) => {
       return;
     }
 
+    container.current.select("svg").remove();
     svg.current = container.current.append("svg");
     g.current = svg.current.append("g")   //Used for margins
     doughnut.current = g.current.append("g")


### PR DESCRIPTION
This issue cropped up while trying to integrate the gauge into a [carousel](https://github.com/akiran/react-slick) slide. The gauge chart renders two charts instead of one because `initChart` is essentially called twice for the same element