### PR TITLE
Removed css import in index.js

### DIFF
--- a/dist/GaugeChart/index.js
+++ b/dist/GaugeChart/index.js
@@ -11,7 +11,7 @@ var _d = require("d3");
 
 var _propTypes = _interopRequireDefault(require("prop-types"));
 
-require("./style.css");
+// require("./style.css");
 
 var _customHooks = _interopRequireDefault(require("./customHooks"));
 

--- a/dist/GaugeChart/index.js
+++ b/dist/GaugeChart/index.js
@@ -1,7 +1,7 @@
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
-  value: true
+  value: true,
 });
 exports.default = void 0;
 
@@ -11,15 +11,54 @@ var _d = require("d3");
 
 var _propTypes = _interopRequireDefault(require("prop-types"));
 
-// require("./style.css");
+require("./style.css");
 
 var _customHooks = _interopRequireDefault(require("./customHooks"));
 
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+function _interopRequireDefault(obj) {
+  return obj && obj.__esModule ? obj : { default: obj };
+}
 
-function _getRequireWildcardCache() { if (typeof WeakMap !== "function") return null; var cache = new WeakMap(); _getRequireWildcardCache = function _getRequireWildcardCache() { return cache; }; return cache; }
+function _getRequireWildcardCache() {
+  if (typeof WeakMap !== "function") return null;
+  var cache = new WeakMap();
+  _getRequireWildcardCache = function _getRequireWildcardCache() {
+    return cache;
+  };
+  return cache;
+}
 
-function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } var cache = _getRequireWildcardCache(); if (cache && cache.has(obj)) { return cache.get(obj); } var newObj = {}; if (obj != null) { var hasPropertyDescriptor = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = hasPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : null; if (desc && (desc.get || desc.set)) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } } newObj.default = obj; if (cache) { cache.set(obj, newObj); } return newObj; }
+function _interopRequireWildcard(obj) {
+  if (obj && obj.__esModule) {
+    return obj;
+  }
+  var cache = _getRequireWildcardCache();
+  if (cache && cache.has(obj)) {
+    return cache.get(obj);
+  }
+  var newObj = {};
+  if (obj != null) {
+    var hasPropertyDescriptor =
+      Object.defineProperty && Object.getOwnPropertyDescriptor;
+    for (var key in obj) {
+      if (Object.prototype.hasOwnProperty.call(obj, key)) {
+        var desc = hasPropertyDescriptor
+          ? Object.getOwnPropertyDescriptor(obj, key)
+          : null;
+        if (desc && (desc.get || desc.set)) {
+          Object.defineProperty(newObj, key, desc);
+        } else {
+          newObj[key] = obj[key];
+        }
+      }
+    }
+  }
+  newObj.default = obj;
+  if (cache) {
+    cache.set(obj, newObj);
+  }
+  return newObj;
+}
 
 /*
 GaugeChart creates a gauge chart using D3
@@ -35,10 +74,16 @@ var startAngle = -Math.PI / 2; //Negative x-axis
 var endAngle = Math.PI / 2; //Positive x-axis
 
 var defaultStyle = {
-  width: '100%'
+  width: "100%",
 }; // Props that should cause an animation on update
 
-var animateNeedleProps = ['marginInPercent', 'arcPadding', 'percent', 'nrOfLevels', 'animDelay'];
+var animateNeedleProps = [
+  "marginInPercent",
+  "arcPadding",
+  "percent",
+  "nrOfLevels",
+  "animDelay",
+];
 
 var GaugeChart = function GaugeChart(props) {
   var svg = (0, _react.useRef)({});
@@ -66,30 +111,60 @@ var GaugeChart = function GaugeChart(props) {
       initChart();
     }
   }, []);
-  (0, _customHooks.default)(function () {
-    if (props.nrOfLevels || prevProps.current.arcsLength.every(function (a) {
-      return props.arcsLength.includes(a);
-    }) || prevProps.current.colors.every(function (a) {
-      return props.colors.includes(a);
-    })) {
-      setArcData(props, nbArcsToDisplay, colorArray, arcData);
-    } //Initialize chart
-    // Always redraw the chart, but potentially do not animate it
+  (0, _customHooks.default)(
+    function () {
+      if (
+        props.nrOfLevels ||
+        prevProps.current.arcsLength.every(function (a) {
+          return props.arcsLength.includes(a);
+        }) ||
+        prevProps.current.colors.every(function (a) {
+          return props.colors.includes(a);
+        })
+      ) {
+        setArcData(props, nbArcsToDisplay, colorArray, arcData);
+      } //Initialize chart
+      // Always redraw the chart, but potentially do not animate it
 
-
-    var resize = !animateNeedleProps.some(function (key) {
-      return prevProps.current[key] !== props[key];
-    });
-    initChart(true, resize, prevProps.current);
-    prevProps.current = props;
-  }, [props.nrOfLevels, props.arcsLength, props.colors, props.percent, props.needleColor, props.needleBaseColor]);
+      var resize = !animateNeedleProps.some(function (key) {
+        return prevProps.current[key] !== props[key];
+      });
+      initChart(true, resize, prevProps.current);
+      prevProps.current = props;
+    },
+    [
+      props.nrOfLevels,
+      props.arcsLength,
+      props.colors,
+      props.percent,
+      props.needleColor,
+      props.needleBaseColor,
+    ]
+  );
 
   var initChart = function initChart(update) {
-    var resize = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : false;
+    var resize =
+      arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : false;
     var prevProps = arguments.length > 2 ? arguments[2] : undefined;
 
     if (update) {
-      renderChart(resize, prevProps, width, margin, height, outerRadius, g, doughnut, arcChart, needle, pieChart, svg, props, container, arcData);
+      renderChart(
+        resize,
+        prevProps,
+        width,
+        margin,
+        height,
+        outerRadius,
+        g,
+        doughnut,
+        arcChart,
+        needle,
+        pieChart,
+        svg,
+        props,
+        container,
+        arcData
+      );
       return;
     }
 
@@ -99,27 +174,62 @@ var GaugeChart = function GaugeChart(props) {
     doughnut.current = g.current.append("g").attr("class", "doughnut"); //Set up the pie generator
     //Each arc should be of equal length (or should they?)
 
-    pieChart.current.value(function (d) {
-      return d.value;
-    }) //.padAngle(arcPadding)
-    .startAngle(startAngle).endAngle(endAngle).sort(null); //Add the needle element
+    pieChart.current
+      .value(function (d) {
+        return d.value;
+      }) //.padAngle(arcPadding)
+      .startAngle(startAngle)
+      .endAngle(endAngle)
+      .sort(null); //Add the needle element
 
-    needle.current = g.current.append('g').attr('class', 'needle'); //Set up resize event listener to re-render the chart everytime the window is resized
+    needle.current = g.current.append("g").attr("class", "needle"); //Set up resize event listener to re-render the chart everytime the window is resized
 
-    window.addEventListener('resize', function () {
+    window.addEventListener("resize", function () {
       var resize = true;
-      renderChart(resize, prevProps, width, margin, height, outerRadius, g, doughnut, arcChart, needle, pieChart, svg, props, container, arcData);
+      renderChart(
+        resize,
+        prevProps,
+        width,
+        margin,
+        height,
+        outerRadius,
+        g,
+        doughnut,
+        arcChart,
+        needle,
+        pieChart,
+        svg,
+        props,
+        container,
+        arcData
+      );
     });
-    renderChart(resize, prevProps, width, margin, height, outerRadius, g, doughnut, arcChart, needle, pieChart, svg, props, container, arcData);
+    renderChart(
+      resize,
+      prevProps,
+      width,
+      margin,
+      height,
+      outerRadius,
+      g,
+      doughnut,
+      arcChart,
+      needle,
+      pieChart,
+      svg,
+      props,
+      container,
+      arcData
+    );
   };
 
   var id = props.id,
-      style = props.style,
-      className = props.className;
+    style = props.style,
+    className = props.className;
   return _react.default.createElement("div", {
     id: id,
     className: className,
-    style: style
+    style: style,
   });
 };
 
@@ -135,15 +245,15 @@ GaugeChart.defaultProps = {
   //The padding between arcs, in rad
   arcWidth: 0.2,
   //The width of the arc given in percent of the radius
-  colors: ['#00FF00', '#FF0000'],
+  colors: ["#00FF00", "#FF0000"],
   //Default defined colors
-  textColor: '#fff',
-  needleColor: '#464A4F',
-  needleBaseColor: '#464A4F',
+  textColor: "#fff",
+  needleColor: "#464A4F",
+  needleBaseColor: "#464A4F",
   hideText: false,
   animate: true,
   animDelay: 500,
-  formatTextValue: null
+  formatTextValue: null,
 };
 GaugeChart.propTypes = {
   id: _propTypes.default.string.isRequired,
@@ -162,13 +272,20 @@ GaugeChart.propTypes = {
   needleBaseColor: _propTypes.default.string,
   hideText: _propTypes.default.bool,
   animate: _propTypes.default.bool,
-  formatTextValue: _propTypes.default.func
+  formatTextValue: _propTypes.default.func,
 }; // This function update arc's datas when component is mounting or when one of arc's props is updated
 
-var setArcData = function setArcData(props, nbArcsToDisplay, colorArray, arcData) {
+var setArcData = function setArcData(
+  props,
+  nbArcsToDisplay,
+  colorArray,
+  arcData
+) {
   // We have to make a decision about number of arcs to display
   // If arcsLength is setted, we choose arcsLength length instead of nrOfLevels
-  nbArcsToDisplay.current = props.arcsLength ? props.arcsLength.length : props.nrOfLevels; //Check if the number of colors equals the number of levels
+  nbArcsToDisplay.current = props.arcsLength
+    ? props.arcsLength.length
+    : props.nrOfLevels; //Check if the number of colors equals the number of levels
   //Otherwise make an interpolation
 
   if (nbArcsToDisplay.current === props.colors.length) {
@@ -178,50 +295,103 @@ var setArcData = function setArcData(props, nbArcsToDisplay, colorArray, arcData
   } //The data that is used to create the arc
   // Each arc could have hiw own value width arcsLength prop
 
-
   arcData.current = [];
 
   for (var i = 0; i < nbArcsToDisplay.current; i++) {
     var arcDatum = {
-      value: props.arcsLength && props.arcsLength.length > i ? props.arcsLength[i] : 1,
-      color: colorArray.current[i]
+      value:
+        props.arcsLength && props.arcsLength.length > i
+          ? props.arcsLength[i]
+          : 1,
+      color: colorArray.current[i],
     };
     arcData.current.push(arcDatum);
   }
 }; //Renders the chart, should be called every time the window is resized
 
-
-var renderChart = function renderChart(resize, prevProps, width, margin, height, outerRadius, g, doughnut, arcChart, needle, pieChart, svg, props, container, arcData) {
+var renderChart = function renderChart(
+  resize,
+  prevProps,
+  width,
+  margin,
+  height,
+  outerRadius,
+  g,
+  doughnut,
+  arcChart,
+  needle,
+  pieChart,
+  svg,
+  props,
+  container,
+  arcData
+) {
   updateDimensions(props, container, margin, width, height); //Set dimensions of svg element and translations
 
-  svg.current.attr('width', width.current + margin.current.left + margin.current.right).attr('height', height.current + margin.current.top + margin.current.bottom);
-  g.current.attr('transform', 'translate(' + margin.current.left + ', ' + margin.current.top + ')'); //Set the radius to lesser of width or height and remove the margins
+  svg.current
+    .attr("width", width.current + margin.current.left + margin.current.right)
+    .attr(
+      "height",
+      height.current + margin.current.top + margin.current.bottom
+    );
+  g.current.attr(
+    "transform",
+    "translate(" + margin.current.left + ", " + margin.current.top + ")"
+  ); //Set the radius to lesser of width or height and remove the margins
   //Calculate the new radius
 
   calculateRadius(width, height, outerRadius, margin, g);
-  doughnut.current.attr('transform', 'translate(' + outerRadius.current + ', ' + outerRadius.current + ')'); //Setup the arc
+  doughnut.current.attr(
+    "transform",
+    "translate(" + outerRadius.current + ", " + outerRadius.current + ")"
+  ); //Setup the arc
 
-  arcChart.current.outerRadius(outerRadius.current).innerRadius(outerRadius.current * (1 - props.arcWidth)).cornerRadius(props.cornerRadius).padAngle(props.arcPadding); //Remove the old stuff
+  arcChart.current
+    .outerRadius(outerRadius.current)
+    .innerRadius(outerRadius.current * (1 - props.arcWidth))
+    .cornerRadius(props.cornerRadius)
+    .padAngle(props.arcPadding); //Remove the old stuff
 
-  doughnut.current.selectAll('.arc').remove();
-  needle.current.selectAll('*').remove();
-  g.current.selectAll('.text-group').remove(); //Draw the arc
+  doughnut.current.selectAll(".arc").remove();
+  needle.current.selectAll("*").remove();
+  g.current.selectAll(".text-group").remove(); //Draw the arc
 
-  var arcPaths = doughnut.current.selectAll('.arc').data(pieChart.current(arcData.current)).enter().append('g').attr('class', 'arc');
-  arcPaths.append('path').attr('d', arcChart.current).style('fill', function (d) {
-    return d.data.color;
-  });
-  drawNeedle(resize, prevProps, props, width, needle, container, outerRadius, g); //Translate the needle starting point to the middle of the arc
+  var arcPaths = doughnut.current
+    .selectAll(".arc")
+    .data(pieChart.current(arcData.current))
+    .enter()
+    .append("g")
+    .attr("class", "arc");
+  arcPaths
+    .append("path")
+    .attr("d", arcChart.current)
+    .style("fill", function (d) {
+      return d.data.color;
+    });
+  drawNeedle(
+    resize,
+    prevProps,
+    props,
+    width,
+    needle,
+    container,
+    outerRadius,
+    g
+  ); //Translate the needle starting point to the middle of the arc
 
-  needle.current.attr('transform', 'translate(' + outerRadius.current + ', ' + outerRadius.current + ')');
+  needle.current.attr(
+    "transform",
+    "translate(" + outerRadius.current + ", " + outerRadius.current + ")"
+  );
 }; //Depending on the number of levels in the chart
 //This function returns the same number of colors
 
-
 var getColors = function getColors(props, nbArcsToDisplay) {
   var colors = props.colors;
-  var colorScale = (0, _d.scaleLinear)().domain([1, nbArcsToDisplay.current]).range([colors[0], colors[colors.length - 1]]) //Use the first and the last color as range
-  .interpolate(_d.interpolateHsl);
+  var colorScale = (0, _d.scaleLinear)()
+    .domain([1, nbArcsToDisplay.current])
+    .range([colors[0], colors[colors.length - 1]]) //Use the first and the last color as range
+    .interpolate(_d.interpolateHsl);
   var colorArray = [];
 
   for (var i = 1; i <= nbArcsToDisplay.current; i++) {
@@ -231,77 +401,141 @@ var getColors = function getColors(props, nbArcsToDisplay) {
   return colorArray;
 }; //If 'resize' is true then the animation does not play
 
-
-var drawNeedle = function drawNeedle(resize, prevProps, props, width, needle, container, outerRadius, g) {
+var drawNeedle = function drawNeedle(
+  resize,
+  prevProps,
+  props,
+  width,
+  needle,
+  container,
+  outerRadius,
+  g
+) {
   var percent = props.percent,
-      needleColor = props.needleColor,
-      needleBaseColor = props.needleBaseColor,
-      hideText = props.hideText,
-      animate = props.animate;
+    needleColor = props.needleColor,
+    needleBaseColor = props.needleBaseColor,
+    hideText = props.hideText,
+    animate = props.animate;
   var needleRadius = 15 * (width.current / 500),
-      // Make the needle radius responsive
-  centerPoint = [0, -needleRadius / 2]; //Draw the triangle
+    // Make the needle radius responsive
+    centerPoint = [0, -needleRadius / 2]; //Draw the triangle
   //var pathStr = `M ${leftPoint[0]} ${leftPoint[1]} L ${topPoint[0]} ${topPoint[1]} L ${rightPoint[0]} ${rightPoint[1]}`;
 
   var prevPercent = prevProps ? prevProps.percent : 0;
   var pathStr = calculateRotation(prevPercent || percent, outerRadius, width);
   needle.current.append("path").attr("d", pathStr).attr("fill", needleColor); //Add a circle at the bottom of needle
 
-  needle.current.append('circle').attr('cx', centerPoint[0]).attr('cy', centerPoint[1]).attr('r', needleRadius).attr('fill', needleBaseColor);
+  needle.current
+    .append("circle")
+    .attr("cx", centerPoint[0])
+    .attr("cy", centerPoint[1])
+    .attr("r", needleRadius)
+    .attr("fill", needleBaseColor);
 
   if (!hideText) {
     addText(percent, props, outerRadius, width, g);
   } //Rotate the needle
 
-
   if (!resize && animate) {
-    needle.current.transition().delay(props.animDelay).ease(_d.easeElastic).duration(3000).tween('progress', function () {
-      var currentPercent = (0, _d.interpolateNumber)(prevPercent, percent);
-      return function (percentOfPercent) {
-        var progress = currentPercent(percentOfPercent);
-        return container.current.select(".needle path").attr("d", calculateRotation(progress, outerRadius, width));
-      };
-    });
+    needle.current
+      .transition()
+      .delay(props.animDelay)
+      .ease(_d.easeElastic)
+      .duration(3000)
+      .tween("progress", function () {
+        var currentPercent = (0, _d.interpolateNumber)(prevPercent, percent);
+        return function (percentOfPercent) {
+          var progress = currentPercent(percentOfPercent);
+          return container.current
+            .select(".needle path")
+            .attr("d", calculateRotation(progress, outerRadius, width));
+        };
+      });
   } else {
-    container.current.select(".needle path").attr("d", calculateRotation(percent, outerRadius, width));
+    container.current
+      .select(".needle path")
+      .attr("d", calculateRotation(percent, outerRadius, width));
   }
 };
 
-var calculateRotation = function calculateRotation(percent, outerRadius, width) {
+var calculateRotation = function calculateRotation(
+  percent,
+  outerRadius,
+  width
+) {
   var needleLength = outerRadius.current * 0.55,
-      //TODO: Maybe it should be specified as a percentage of the arc radius?
-  needleRadius = 15 * (width.current / 500),
-      theta = percentToRad(percent),
-      centerPoint = [0, -needleRadius / 2],
-      topPoint = [centerPoint[0] - needleLength * Math.cos(theta), centerPoint[1] - needleLength * Math.sin(theta)],
-      leftPoint = [centerPoint[0] - needleRadius * Math.cos(theta - Math.PI / 2), centerPoint[1] - needleRadius * Math.sin(theta - Math.PI / 2)],
-      rightPoint = [centerPoint[0] - needleRadius * Math.cos(theta + Math.PI / 2), centerPoint[1] - needleRadius * Math.sin(theta + Math.PI / 2)];
-  var pathStr = "M ".concat(leftPoint[0], " ").concat(leftPoint[1], " L ").concat(topPoint[0], " ").concat(topPoint[1], " L ").concat(rightPoint[0], " ").concat(rightPoint[1]);
+    //TODO: Maybe it should be specified as a percentage of the arc radius?
+    needleRadius = 15 * (width.current / 500),
+    theta = percentToRad(percent),
+    centerPoint = [0, -needleRadius / 2],
+    topPoint = [
+      centerPoint[0] - needleLength * Math.cos(theta),
+      centerPoint[1] - needleLength * Math.sin(theta),
+    ],
+    leftPoint = [
+      centerPoint[0] - needleRadius * Math.cos(theta - Math.PI / 2),
+      centerPoint[1] - needleRadius * Math.sin(theta - Math.PI / 2),
+    ],
+    rightPoint = [
+      centerPoint[0] - needleRadius * Math.cos(theta + Math.PI / 2),
+      centerPoint[1] - needleRadius * Math.sin(theta + Math.PI / 2),
+    ];
+  var pathStr = "M "
+    .concat(leftPoint[0], " ")
+    .concat(leftPoint[1], " L ")
+    .concat(topPoint[0], " ")
+    .concat(topPoint[1], " L ")
+    .concat(rightPoint[0], " ")
+    .concat(rightPoint[1]);
   return pathStr;
 }; //Returns the angle (in rad) for the given 'percent' value where percent = 1 means 100% and is 180 degree angle
-
 
 var percentToRad = function percentToRad(percent) {
   return percent * Math.PI;
 }; //Adds text undeneath the graft to display which percentage is the current one
 
-
 var addText = function addText(percentage, props, outerRadius, width, g) {
   var formatTextValue = props.formatTextValue;
   var textPadding = 20;
-  var text = formatTextValue ? formatTextValue(floatingNumber(percentage)) : floatingNumber(percentage) + '%';
-  g.current.append('g').attr('class', 'text-group').attr('transform', "translate(".concat(outerRadius.current, ", ").concat(outerRadius.current / 2 + textPadding, ")")).append('text').text(text) // this computation avoid text overflow. When formatted value is over 10 characters, we should reduce font size
-  .style('font-size', function () {
-    return "".concat(width.current / 11 / (text.length > 10 ? text.length / 10 : 1), "px");
-  }).style('fill', props.textColor).attr('class', 'percent-text');
+  var text = formatTextValue
+    ? formatTextValue(floatingNumber(percentage))
+    : floatingNumber(percentage) + "%";
+  g.current
+    .append("g")
+    .attr("class", "text-group")
+    .attr(
+      "transform",
+      "translate("
+        .concat(outerRadius.current, ", ")
+        .concat(outerRadius.current / 2 + textPadding, ")")
+    )
+    .append("text")
+    .text(text) // this computation avoid text overflow. When formatted value is over 10 characters, we should reduce font size
+    .style("font-size", function () {
+      return "".concat(
+        width.current / 11 / (text.length > 10 ? text.length / 10 : 1),
+        "px"
+      );
+    })
+    .style("fill", props.textColor)
+    .attr("class", "percent-text");
 };
 
 var floatingNumber = function floatingNumber(value) {
-  var maxDigits = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 2;
-  return Math.round(value * 100 * Math.pow(10, maxDigits)) / Math.pow(10, maxDigits);
+  var maxDigits =
+    arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 2;
+  return (
+    Math.round(value * 100 * Math.pow(10, maxDigits)) / Math.pow(10, maxDigits)
+  );
 };
 
-var calculateRadius = function calculateRadius(width, height, outerRadius, margin, g) {
+var calculateRadius = function calculateRadius(
+  width,
+  height,
+  outerRadius,
+  margin,
+  g
+) {
   //The radius needs to be constrained by the containing div
   //Since it is a half circle we are dealing with the height of the div
   //Only needs to be half of the width, because the width needs to be 2 * radius
@@ -310,31 +544,43 @@ var calculateRadius = function calculateRadius(width, height, outerRadius, margi
   if (width.current < 2 * height.current) {
     //Then the width limits the size of the chart
     //Set the radius to the width - the horizontal margins
-    outerRadius.current = (width.current - margin.current.left - margin.current.right) / 2;
+    outerRadius.current =
+      (width.current - margin.current.left - margin.current.right) / 2;
   } else {
-    outerRadius.current = height.current - margin.current.top - margin.current.bottom;
+    outerRadius.current =
+      height.current - margin.current.top - margin.current.bottom;
   }
 
   centerGraph(width, g, outerRadius, margin);
 }; //Calculates new margins to make the graph centered
 
-
 var centerGraph = function centerGraph(width, g, outerRadius, margin) {
-  margin.current.left = width.current / 2 - outerRadius.current + margin.current.right;
-  g.current.attr('transform', 'translate(' + margin.current.left + ', ' + margin.current.top + ')');
+  margin.current.left =
+    width.current / 2 - outerRadius.current + margin.current.right;
+  g.current.attr(
+    "transform",
+    "translate(" + margin.current.left + ", " + margin.current.top + ")"
+  );
 };
 
-var updateDimensions = function updateDimensions(props, container, margin, width, height) {
+var updateDimensions = function updateDimensions(
+  props,
+  container,
+  margin,
+  width,
+  height
+) {
   //TODO: Fix so that the container is included in the component
   var marginInPercent = props.marginInPercent;
   var divDimensions = container.current.node().getBoundingClientRect(),
-      divWidth = divDimensions.width,
-      divHeight = divDimensions.height; //Set the new width and horizontal margins
+    divWidth = divDimensions.width,
+    divHeight = divDimensions.height; //Set the new width and horizontal margins
 
   margin.current.left = divWidth * marginInPercent;
   margin.current.right = divWidth * marginInPercent;
   width.current = divWidth - margin.current.left - margin.current.right;
   margin.current.top = divHeight * marginInPercent;
   margin.current.bottom = divHeight * marginInPercent;
-  height.current = width.current / 2 - margin.current.top - margin.current.bottom; //height.current = divHeight - margin.current.top - margin.current.bottom;
+  height.current =
+    width.current / 2 - margin.current.top - margin.current.bottom; //height.current = divHeight - margin.current.top - margin.current.bottom;
 };

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/BossBele/react-gauge-chart"
+    "url": "https://github.com/Martin36/react-gauge-chart"
   },
   "dependencies": {
     "d3": "^5.12.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "react-gauge-chart",
-  "version": "0.2.5",
+  "name": "react-gauge-chart-nextjs-support",
+  "version": "1.0.0",
   "main": "dist/index",
   "module": "dist/index",
   "typings": "dist/index",
@@ -62,4 +62,5 @@
     "react": "^16.8.2",
     "react-dom": "^16.8.2"
   }
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" }
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/Martin36/react-gauge-chart"
+    "url": "https://github.com/BossBele/react-gauge-chart"
   },
   "dependencies": {
     "d3": "^5.12.0"
@@ -61,6 +61,8 @@
   "peerDependencies": {
     "react": "^16.8.2",
     "react-dom": "^16.8.2"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
   }
-  "publishConfig": { "registry": "https://npm.pkg.github.com/" }
 }

--- a/src/lib/GaugeChart/index.js
+++ b/src/lib/GaugeChart/index.js
@@ -1,9 +1,16 @@
-import React, {useEffect, useRef} from 'react'
-import { arc, pie, select, easeElastic, scaleLinear, interpolateHsl, interpolateNumber } from 'd3'
-import PropTypes from 'prop-types'
+import React, { useEffect, useRef } from "react";
+import {
+  arc,
+  pie,
+  select,
+  easeElastic,
+  scaleLinear,
+  interpolateHsl,
+  interpolateNumber,
+} from "d3";
+import PropTypes from "prop-types";
 
-import './style.css'
-import useDeepCompareEffect from './customHooks'
+import useDeepCompareEffect from "./customHooks";
 /*
 GaugeChart creates a gauge chart using D3
 The chart is responsive and will have the same width as the "container"
@@ -14,97 +21,155 @@ The svg element surrounding the gauge will always be square
 */
 
 //Constants
-const startAngle = -Math.PI / 2 //Negative x-axis
-const endAngle = Math.PI / 2 //Positive x-axis
+const startAngle = -Math.PI / 2; //Negative x-axis
+const endAngle = Math.PI / 2; //Positive x-axis
 
 const defaultStyle = {
-  width: '100%',
+  width: "100%",
 };
 
 // Props that should cause an animation on update
 const animateNeedleProps = [
-  'marginInPercent',
-  'arcPadding',
-  'percent',
-  'nrOfLevels',
-  'animDelay',
+  "marginInPercent",
+  "arcPadding",
+  "percent",
+  "nrOfLevels",
+  "animDelay",
 ];
 
 const GaugeChart = (props) => {
-  const svg = useRef({})
-  const g = useRef({})
-  const width = useRef({})
-  const height = useRef({})
-  const doughnut = useRef({})
-  const needle = useRef({})
-  const outerRadius = useRef({})
-  const margin = useRef({}) // = {top: 20, right: 50, bottom: 50, left: 50},
-  const container = useRef({})
-  const nbArcsToDisplay = useRef(0)
-  const colorArray = useRef([])
-  const arcChart = useRef(arc())
-  const arcData = useRef([])
-  const pieChart = useRef(pie())
-  const prevProps = useRef(props)
+  const svg = useRef({});
+  const g = useRef({});
+  const width = useRef({});
+  const height = useRef({});
+  const doughnut = useRef({});
+  const needle = useRef({});
+  const outerRadius = useRef({});
+  const margin = useRef({}); // = {top: 20, right: 50, bottom: 50, left: 50},
+  const container = useRef({});
+  const nbArcsToDisplay = useRef(0);
+  const colorArray = useRef([]);
+  const arcChart = useRef(arc());
+  const arcData = useRef([]);
+  const pieChart = useRef(pie());
+  const prevProps = useRef(props);
 
   useEffect(() => {
-    setArcData(props, nbArcsToDisplay, colorArray, arcData)
+    setArcData(props, nbArcsToDisplay, colorArray, arcData);
     if (props.id) {
-      container.current = select(`#${props.id}`)
+      container.current = select(`#${props.id}`);
       //Initialize chart
-      initChart()
+      initChart();
     }
-  }, [])
+  }, []);
 
   useDeepCompareEffect(() => {
-    if (props.nrOfLevels ||
-      prevProps.current.arcsLength.every(a => props.arcsLength.includes(a)) ||
-      prevProps.current.colors.every(a => props.colors.includes(a)) ) {
-    setArcData(props, nbArcsToDisplay, colorArray, arcData)
+    if (
+      props.nrOfLevels ||
+      prevProps.current.arcsLength.every((a) => props.arcsLength.includes(a)) ||
+      prevProps.current.colors.every((a) => props.colors.includes(a))
+    ) {
+      setArcData(props, nbArcsToDisplay, colorArray, arcData);
     }
     //Initialize chart
     // Always redraw the chart, but potentially do not animate it
-    const resize = !animateNeedleProps.some(key => prevProps.current[key] !== props[key])
-    initChart(true, resize, prevProps.current)
-    prevProps.current = props
-  }, [props.nrOfLevels, props.arcsLength, props.colors, props.percent, props.needleColor, props.needleBaseColor])
+    const resize = !animateNeedleProps.some(
+      (key) => prevProps.current[key] !== props[key]
+    );
+    initChart(true, resize, prevProps.current);
+    prevProps.current = props;
+  }, [
+    props.nrOfLevels,
+    props.arcsLength,
+    props.colors,
+    props.percent,
+    props.needleColor,
+    props.needleBaseColor,
+  ]);
 
   const initChart = (update, resize = false, prevProps) => {
     if (update) {
-      renderChart(resize, prevProps, width, margin, height, outerRadius, g, doughnut, arcChart, needle, pieChart, svg, props, container, arcData);
+      renderChart(
+        resize,
+        prevProps,
+        width,
+        margin,
+        height,
+        outerRadius,
+        g,
+        doughnut,
+        arcChart,
+        needle,
+        pieChart,
+        svg,
+        props,
+        container,
+        arcData
+      );
       return;
     }
 
     svg.current = container.current.append("svg");
-    g.current = svg.current.append("g")   //Used for margins
-    doughnut.current = g.current.append("g")
-      .attr("class", "doughnut");
+    g.current = svg.current.append("g"); //Used for margins
+    doughnut.current = g.current.append("g").attr("class", "doughnut");
 
-      //Set up the pie generator
+    //Set up the pie generator
     //Each arc should be of equal length (or should they?)
     pieChart.current
-      .value(function(d) {
-        return d.value
+      .value(function (d) {
+        return d.value;
       })
       //.padAngle(arcPadding)
       .startAngle(startAngle)
       .endAngle(endAngle)
-      .sort(null)
+      .sort(null);
     //Add the needle element
-    needle.current = g.current.append('g').attr('class', 'needle')
+    needle.current = g.current.append("g").attr("class", "needle");
     //Set up resize event listener to re-render the chart everytime the window is resized
-    window.addEventListener('resize', () => {
+    window.addEventListener("resize", () => {
       var resize = true;
-      renderChart(resize, prevProps, width, margin, height, outerRadius, g, doughnut, arcChart, needle, pieChart, svg, props, container, arcData);
+      renderChart(
+        resize,
+        prevProps,
+        width,
+        margin,
+        height,
+        outerRadius,
+        g,
+        doughnut,
+        arcChart,
+        needle,
+        pieChart,
+        svg,
+        props,
+        container,
+        arcData
+      );
     });
-    renderChart(resize, prevProps, width, margin, height, outerRadius, g, doughnut, arcChart, needle, pieChart, svg, props, container, arcData);
-  }
-    
+    renderChart(
+      resize,
+      prevProps,
+      width,
+      margin,
+      height,
+      outerRadius,
+      g,
+      doughnut,
+      arcChart,
+      needle,
+      pieChart,
+      svg,
+      props,
+      container,
+      arcData
+    );
+  };
+
   const { id, style, className } = props;
   return <div id={id} className={className} style={style} />;
-}
+};
 
-export default GaugeChart
+export default GaugeChart;
 
 GaugeChart.defaultProps = {
   style: defaultStyle,
@@ -114,17 +179,17 @@ GaugeChart.defaultProps = {
   percent: 0.4,
   arcPadding: 0.05, //The padding between arcs, in rad
   arcWidth: 0.2, //The width of the arc given in percent of the radius
-  colors: ['#00FF00', '#FF0000'], //Default defined colors
-  textColor: '#fff',
-  needleColor: '#464A4F',
-  needleBaseColor: '#464A4F',
+  colors: ["#00FF00", "#FF0000"], //Default defined colors
+  textColor: "#fff",
+  needleColor: "#464A4F",
+  needleBaseColor: "#464A4F",
   hideText: false,
   animate: true,
   animDelay: 500,
   formatTextValue: null,
   fontSize: null,
-  animateDuration: 3000
-}
+  animateDuration: 3000,
+};
 
 GaugeChart.propTypes = {
   id: PropTypes.string.isRequired,
@@ -146,177 +211,240 @@ GaugeChart.propTypes = {
   formatTextValue: PropTypes.func,
   fontSize: PropTypes.string,
   animateDuration: PropTypes.number,
-}
+};
 
- // This function update arc's datas when component is mounting or when one of arc's props is updated
+// This function update arc's datas when component is mounting or when one of arc's props is updated
 const setArcData = (props, nbArcsToDisplay, colorArray, arcData) => {
   // We have to make a decision about number of arcs to display
   // If arcsLength is setted, we choose arcsLength length instead of nrOfLevels
-  nbArcsToDisplay.current = props.arcsLength ? props.arcsLength.length : props.nrOfLevels
+  nbArcsToDisplay.current = props.arcsLength
+    ? props.arcsLength.length
+    : props.nrOfLevels;
 
   //Check if the number of colors equals the number of levels
   //Otherwise make an interpolation
   if (nbArcsToDisplay.current === props.colors.length) {
-    colorArray.current = props.colors
+    colorArray.current = props.colors;
   } else {
-    colorArray.current = getColors(props, nbArcsToDisplay)
+    colorArray.current = getColors(props, nbArcsToDisplay);
   }
   //The data that is used to create the arc
   // Each arc could have hiw own value width arcsLength prop
-  arcData.current = []
+  arcData.current = [];
   for (var i = 0; i < nbArcsToDisplay.current; i++) {
     var arcDatum = {
-      value: props.arcsLength && props.arcsLength.length > i ? props.arcsLength[i] : 1,
-      color: colorArray.current[i]
-    }
-    arcData.current.push(arcDatum)
+      value:
+        props.arcsLength && props.arcsLength.length > i
+          ? props.arcsLength[i]
+          : 1,
+      color: colorArray.current[i],
+    };
+    arcData.current.push(arcDatum);
   }
-}
+};
 
 //Renders the chart, should be called every time the window is resized
-const renderChart = (resize, prevProps, width, margin, height, outerRadius, g, doughnut, arcChart, needle, pieChart, svg, props, container, arcData) => {
+const renderChart = (
+  resize,
+  prevProps,
+  width,
+  margin,
+  height,
+  outerRadius,
+  g,
+  doughnut,
+  arcChart,
+  needle,
+  pieChart,
+  svg,
+  props,
+  container,
+  arcData
+) => {
   updateDimensions(props, container, margin, width, height);
   //Set dimensions of svg element and translations
   svg.current
-    .attr('width', width.current + margin.current.left + margin.current.right)
-    .attr('height', height.current + margin.current.top + margin.current.bottom)
-  g.current.attr('transform', 'translate(' + margin.current.left + ', ' + margin.current.top + ')')
+    .attr("width", width.current + margin.current.left + margin.current.right)
+    .attr(
+      "height",
+      height.current + margin.current.top + margin.current.bottom
+    );
+  g.current.attr(
+    "transform",
+    "translate(" + margin.current.left + ", " + margin.current.top + ")"
+  );
   //Set the radius to lesser of width or height and remove the margins
   //Calculate the new radius
-  calculateRadius(width, height, outerRadius, margin, g)
-  doughnut.current.attr('transform', 'translate(' + outerRadius.current + ', ' + outerRadius.current + ')')
+  calculateRadius(width, height, outerRadius, margin, g);
+  doughnut.current.attr(
+    "transform",
+    "translate(" + outerRadius.current + ", " + outerRadius.current + ")"
+  );
   //Setup the arc
   arcChart.current
     .outerRadius(outerRadius.current)
     .innerRadius(outerRadius.current * (1 - props.arcWidth))
     .cornerRadius(props.cornerRadius)
-    .padAngle(props.arcPadding)
+    .padAngle(props.arcPadding);
   //Remove the old stuff
-  doughnut.current.selectAll('.arc').remove()
-  needle.current.selectAll('*').remove()
-  g.current.selectAll('.text-group').remove()
+  doughnut.current.selectAll(".arc").remove();
+  needle.current.selectAll("*").remove();
+  g.current.selectAll(".text-group").remove();
   //Draw the arc
   var arcPaths = doughnut.current
-    .selectAll('.arc')
+    .selectAll(".arc")
     .data(pieChart.current(arcData.current))
     .enter()
-    .append('g')
-    .attr('class', 'arc')
+    .append("g")
+    .attr("class", "arc");
   arcPaths
-    .append('path')
-    .attr('d', arcChart.current)
-    .style('fill', function(d) {
-      return d.data.color
-    })
+    .append("path")
+    .attr("d", arcChart.current)
+    .style("fill", function (d) {
+      return d.data.color;
+    });
 
-  drawNeedle(resize, prevProps, props, width, needle, container, outerRadius, g);
+  drawNeedle(
+    resize,
+    prevProps,
+    props,
+    width,
+    needle,
+    container,
+    outerRadius,
+    g
+  );
   //Translate the needle starting point to the middle of the arc
-  needle.current.attr('transform', 'translate(' + outerRadius.current + ', ' + outerRadius.current + ')')
-}
+  needle.current.attr(
+    "transform",
+    "translate(" + outerRadius.current + ", " + outerRadius.current + ")"
+  );
+};
 
 //Depending on the number of levels in the chart
 //This function returns the same number of colors
 const getColors = (props, nbArcsToDisplay) => {
-  const { colors } = props
+  const { colors } = props;
   var colorScale = scaleLinear()
     .domain([1, nbArcsToDisplay.current])
     .range([colors[0], colors[colors.length - 1]]) //Use the first and the last color as range
-    .interpolate(interpolateHsl)
-  var colorArray = []
+    .interpolate(interpolateHsl);
+  var colorArray = [];
   for (var i = 1; i <= nbArcsToDisplay.current; i++) {
-    colorArray.push(colorScale(i))
+    colorArray.push(colorScale(i));
   }
-  return colorArray
-}
+  return colorArray;
+};
 
 //If 'resize' is true then the animation does not play
-const drawNeedle = (resize, prevProps, props, width, needle, container, outerRadius, g) => {
+const drawNeedle = (
+  resize,
+  prevProps,
+  props,
+  width,
+  needle,
+  container,
+  outerRadius,
+  g
+) => {
   const { percent, needleColor, needleBaseColor, hideText, animate } = props;
-  var needleRadius = 15*(width.current / 500) ,   // Make the needle radius responsive
-      centerPoint = [0, -needleRadius/2];
+  var needleRadius = 15 * (width.current / 500), // Make the needle radius responsive
+    centerPoint = [0, -needleRadius / 2];
   //Draw the triangle
   //var pathStr = `M ${leftPoint[0]} ${leftPoint[1]} L ${topPoint[0]} ${topPoint[1]} L ${rightPoint[0]} ${rightPoint[1]}`;
   const prevPercent = prevProps ? prevProps.percent : 0;
   var pathStr = calculateRotation(prevPercent || percent, outerRadius, width);
-  needle.current.append("path")
-    .attr("d", pathStr)
-    .attr("fill", needleColor);
+  needle.current.append("path").attr("d", pathStr).attr("fill", needleColor);
   //Add a circle at the bottom of needle
   needle.current
-    .append('circle')
-    .attr('cx', centerPoint[0])
-    .attr('cy', centerPoint[1])
-    .attr('r', needleRadius)
-    .attr('fill', needleBaseColor)
+    .append("circle")
+    .attr("cx", centerPoint[0])
+    .attr("cy", centerPoint[1])
+    .attr("r", needleRadius)
+    .attr("fill", needleBaseColor);
   if (!hideText) {
-    addText(percent, props, outerRadius, width, g)
+    addText(percent, props, outerRadius, width, g);
   }
   //Rotate the needle
-  if(!resize && animate){
-    needle.current.transition()
-    .delay(props.animDelay)
-    .ease(easeElastic)
-    .duration(props.animateDuration)
-    .tween('progress', function(){
-      const currentPercent = interpolateNumber(prevPercent, percent);
-      return function(percentOfPercent){
-        const progress = currentPercent(percentOfPercent);
-        return container.current.select(`.needle path`).attr("d", calculateRotation(progress, outerRadius, width));
-      }
-    });
+  if (!resize && animate) {
+    needle.current
+      .transition()
+      .delay(props.animDelay)
+      .ease(easeElastic)
+      .duration(props.animateDuration)
+      .tween("progress", function () {
+        const currentPercent = interpolateNumber(prevPercent, percent);
+        return function (percentOfPercent) {
+          const progress = currentPercent(percentOfPercent);
+          return container.current
+            .select(`.needle path`)
+            .attr("d", calculateRotation(progress, outerRadius, width));
+        };
+      });
+  } else {
+    container.current
+      .select(`.needle path`)
+      .attr("d", calculateRotation(percent, outerRadius, width));
   }
-  else{
-    container.current.select(`.needle path`).attr("d", calculateRotation(percent, outerRadius, width));
-  }
-}
+};
 
 const calculateRotation = (percent, outerRadius, width) => {
   var needleLength = outerRadius.current * 0.55, //TODO: Maybe it should be specified as a percentage of the arc radius?
     needleRadius = 15 * (width.current / 500),
     theta = percentToRad(percent),
     centerPoint = [0, -needleRadius / 2],
-    topPoint = [centerPoint[0] - needleLength * Math.cos(theta), centerPoint[1] - needleLength * Math.sin(theta)],
+    topPoint = [
+      centerPoint[0] - needleLength * Math.cos(theta),
+      centerPoint[1] - needleLength * Math.sin(theta),
+    ],
     leftPoint = [
       centerPoint[0] - needleRadius * Math.cos(theta - Math.PI / 2),
-      centerPoint[1] - needleRadius * Math.sin(theta - Math.PI / 2)
+      centerPoint[1] - needleRadius * Math.sin(theta - Math.PI / 2),
     ],
     rightPoint = [
       centerPoint[0] - needleRadius * Math.cos(theta + Math.PI / 2),
-      centerPoint[1] - needleRadius * Math.sin(theta + Math.PI / 2)
-    ]
-  var pathStr = `M ${leftPoint[0]} ${leftPoint[1]} L ${topPoint[0]} ${topPoint[1]} L ${rightPoint[0]} ${
-    rightPoint[1]
-  }`
-  return pathStr
-}
+      centerPoint[1] - needleRadius * Math.sin(theta + Math.PI / 2),
+    ];
+  var pathStr = `M ${leftPoint[0]} ${leftPoint[1]} L ${topPoint[0]} ${topPoint[1]} L ${rightPoint[0]} ${rightPoint[1]}`;
+  return pathStr;
+};
 
 //Returns the angle (in rad) for the given 'percent' value where percent = 1 means 100% and is 180 degree angle
-const percentToRad = percent => {
-  return percent * Math.PI
-}
+const percentToRad = (percent) => {
+  return percent * Math.PI;
+};
 
 //Adds text undeneath the graft to display which percentage is the current one
 const addText = (percentage, props, outerRadius, width, g) => {
-  const { formatTextValue, fontSize } = props
-  var textPadding = 20
+  const { formatTextValue, fontSize } = props;
+  var textPadding = 20;
   const text = formatTextValue
     ? formatTextValue(floatingNumber(percentage))
-    : floatingNumber(percentage) + '%'
+    : floatingNumber(percentage) + "%";
   g.current
-    .append('g')
-    .attr('class', 'text-group')
-    .attr('transform', `translate(${outerRadius.current}, ${outerRadius.current / 2 + textPadding})`)
-    .append('text')
+    .append("g")
+    .attr("class", "text-group")
+    .attr(
+      "transform",
+      `translate(${outerRadius.current}, ${
+        outerRadius.current / 2 + textPadding
+      })`
+    )
+    .append("text")
     .text(text)
     // this computation avoid text overflow. When formatted value is over 10 characters, we should reduce font size
-    .style('font-size', () => fontSize ? fontSize : `${width.current / 11 / (text.length > 10 ? text.length / 10 : 1)}px`)
-    .style('fill', props.textColor)
-    .attr('class', 'percent-text')
-}
+    .style("font-size", () =>
+      fontSize
+        ? fontSize
+        : `${width.current / 11 / (text.length > 10 ? text.length / 10 : 1)}px`
+    )
+    .style("fill", props.textColor)
+    .style("text-anchor", "middle");
+};
 
 const floatingNumber = (value, maxDigits = 2) => {
-  return Math.round(value * 100 * 10 ** maxDigits) / 10 ** maxDigits
-}
+  return Math.round(value * 100 * 10 ** maxDigits) / 10 ** maxDigits;
+};
 
 const calculateRadius = (width, height, outerRadius, margin, g) => {
   //The radius needs to be constrained by the containing div
@@ -328,33 +456,40 @@ const calculateRadius = (width, height, outerRadius, margin, g) => {
   if (width.current < 2 * height.current) {
     //Then the width limits the size of the chart
     //Set the radius to the width - the horizontal margins
-    outerRadius.current = (width.current - margin.current.left - margin.current.right) / 2
+    outerRadius.current =
+      (width.current - margin.current.left - margin.current.right) / 2;
   } else {
-    outerRadius.current = height.current - margin.current.top - margin.current.bottom
+    outerRadius.current =
+      height.current - margin.current.top - margin.current.bottom;
   }
-  centerGraph(width, g, outerRadius, margin)
-}
+  centerGraph(width, g, outerRadius, margin);
+};
 
 //Calculates new margins to make the graph centered
 const centerGraph = (width, g, outerRadius, margin) => {
-  margin.current.left = width.current / 2 - outerRadius.current + margin.current.right
-  g.current.attr('transform', 'translate(' + margin.current.left + ', ' + margin.current.top + ')')
-}
+  margin.current.left =
+    width.current / 2 - outerRadius.current + margin.current.right;
+  g.current.attr(
+    "transform",
+    "translate(" + margin.current.left + ", " + margin.current.top + ")"
+  );
+};
 
 const updateDimensions = (props, container, margin, width, height) => {
   //TODO: Fix so that the container is included in the component
-  const { marginInPercent } = props
+  const { marginInPercent } = props;
   var divDimensions = container.current.node().getBoundingClientRect(),
-      divWidth = divDimensions.width,
-      divHeight = divDimensions.height;
+    divWidth = divDimensions.width,
+    divHeight = divDimensions.height;
 
   //Set the new width and horizontal margins
-  margin.current.left = divWidth * marginInPercent
-  margin.current.right = divWidth * marginInPercent
-  width.current = divWidth - margin.current.left - margin.current.right
+  margin.current.left = divWidth * marginInPercent;
+  margin.current.right = divWidth * marginInPercent;
+  width.current = divWidth - margin.current.left - margin.current.right;
 
-  margin.current.top = divHeight * marginInPercent
-  margin.current.bottom = divHeight * marginInPercent
-  height.current = width.current / 2 - margin.current.top - margin.current.bottom
+  margin.current.top = divHeight * marginInPercent;
+  margin.current.bottom = divHeight * marginInPercent;
+  height.current =
+    width.current / 2 - margin.current.top - margin.current.bottom;
   //height.current = divHeight - margin.current.top - margin.current.bottom;
-}
+};

--- a/src/lib/GaugeChart/style.css
+++ b/src/lib/GaugeChart/style.css
@@ -1,4 +1,0 @@
-.percent-text{
-  text-anchor: middle;
-  font-family: 'Roboto', sans-serif;
-}


### PR DESCRIPTION
This is required for nextJS support:

```
./node_modules/react-gauge-chart/dist/GaugeChart/style.css
Global CSS cannot be imported from within node_modules.
Read more: https://err.sh/next.js/css-npm
Location: node_modules/react-gauge-chart/dist/GaugeChart/index.js
```
Perhaps this is not the best solution, but it is a temporary solution to this problem. Please find a way to fix this. The community at nextJS needs it.