### PR TITLE
Peer dependencies for React 17 and 16.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,15 +52,15 @@
     "babel-preset-react-app": "^8.0.0",
     "cross-env": "^5.2.1",
     "gh-pages": "^2.1.1",
-    "react": "^16.10.1",
+    "react": "^17.0.1",
     "react-bootstrap": "^1.4.0",
-    "react-dom": "^16.10.1",
-    "react-scripts": "2.1.5",
+    "react-dom": "^17.0.1",
+    "react-scripts": "4.0.0",
     "rimraf": "^2.7.1"
   },
   "peerDependencies": {
-    "react": "^16.8.2",
-    "react-dom": "^16.8.2"
+    "react": "^16.8.2 || ^17.0",
+    "react-dom": "^16.8.2 || ^17.0"
   },
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/"


### PR DESCRIPTION
Support both React 16.8+ and 17.0
Example app now starts with React 17

Fixes #63 