### PR TITLE
Removed useEffectLayout warning

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom';
 import './index.css';
 import App from './App';
 import * as serviceWorker from './serviceWorker';
+React.useLayoutEffect = React.useEffect;
 
 ReactDOM.render(<App />, document.getElementById('root'));
 


### PR DESCRIPTION
I've been using this component for a bit in a Next.js project and i got this error. There is a simple way to solve it but I don't know if there is the right place for this code. Let me know if you like to move it to another place.

> Warning: useLayoutEffect does nothing on the server, because its effect cannot be encoded into the server renderer's output format. This will lead to a mismatch between the initial, non-hydrated UI and the intended UI. To avoid this, useLayoutEffect should only be used in components that render exclusively on the client. See https://reactjs.org/link/uselayouteffect-ssr for common fixes.