### PR TITLE
Bundle optimisation by using only required module from lodash (lodash 530 kb to 60kb)

### DIFF
--- a/src/lib/GaugeChart/customHooks.js
+++ b/src/lib/GaugeChart/customHooks.js
@@ -1,8 +1,8 @@
-import _ from "lodash";
+import isEqual from "lodash/isEqual";
 import { useEffect, useRef } from "react";
 
 const isDeepEquals = (toCompare, reference) => {
-  return _.isEqual(toCompare, reference);
+  return isEqual(toCompare, reference);
 };
 
 const useDeepCompareMemo = (dependencies) => {


### PR DESCRIPTION
Bundle size can be reduced if we import only required modules.
**Changes - just imported only isEqual method from lodas instead of importing default**
## Bundle analyzer report before - 530 KB for lodash
![image](https://user-images.githubusercontent.com/51072177/203232649-ff20fb23-791b-4746-a372-3f2bb19f8330.png)

## Bundle analyzer report after this change - 60.86 KB for lodash
![image](https://user-images.githubusercontent.com/51072177/203233224-aaefb680-0dc1-44e6-996e-cd2febf9b41b.png)
