### PR TITLE
fix: removed props as dependency array

### DIFF
--- a/src/lib/GaugeChart/index.js
+++ b/src/lib/GaugeChart/index.js
@@ -175,7 +175,8 @@ const GaugeChart = (props) => {
     return () => {
       window.removeEventListener("resize", handleResize);
     };
-  }, [props]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const { id, style, className } = props;
   return (


### PR DESCRIPTION
Removed props as dependency array.
The reference of prop's object keeps changing, & causing useEffect to run multiple times.